### PR TITLE
Refactor dir_path argument handling in main

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,40 +2,21 @@
 #include <iostream>
 #include "include/file_editor.hpp"
 
-/*Fixes the path taken as argument when starting the program.*/
-std::string formatPath(int argc, std::string argv) {
-    char cwd[256];
-    std::string complete_path;
-    if (argc == 1 || (argc == 2 && argv == ".")) {
-        getcwd(cwd, sizeof(cwd));
-        complete_path = std::string(cwd);
-    } else {
-        char first_char_argv = argv[0];
-        if (&first_char_argv == std::string("/")) {
-            complete_path = argv;
-        } else {
-            complete_path = std::string(getcwd(cwd, sizeof(cwd))) + "/" + argv;
-        }
-    }
-    return complete_path;
-}
-
 int main(int argc, char* argv[]) {
-    std::string dir_path = "";
-    if (argc > 2) {
-        std::cout << "Max 2 arguments allowed\n";
+    if (argc != 2) {
+        std::cout << "Usage: " << argv[0] << " [path to dir]" << std::endl; 
         return -1;
-    } else if (argc == 2) {
-        dir_path = formatPath(argc, argv[1]);
-    } else {
-        dir_path = formatPath(argc, "");
     }
+
     try {
+        std::string dir_path = std::filesystem::canonical(argv[1]);
         FileEditor editor(dir_path);
         editor.runtime();
-    }
-    catch(std::invalid_argument& e) {
+    } catch(std::invalid_argument& e) {
         std::cerr << e.what() << std::endl;
+        return -1;
+    } catch(std::filesystem::filesystem_error& e) {
+        std::cerr << "Unable to resolve the given directory path.\n"<< e.what() << std::endl;
         return -1;
     }
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 
 int main(int argc, char* argv[]) {
     if (argc != 2) {
-        std::cout << "Usage: " << argv[0] << " [path to dir]" << std::endl; 
+        std::cout << "Usage: " << argv[0] << " [path to dir]" << std::endl;
         return -1;
     }
 
@@ -16,7 +16,8 @@ int main(int argc, char* argv[]) {
         std::cerr << e.what() << std::endl;
         return -1;
     } catch(std::filesystem::filesystem_error& e) {
-        std::cerr << "Unable to resolve the given directory path.\n"<< e.what() << std::endl;
+        std::cerr << "Unable to resolve the given directory path.\n"
+            << e.what() << std::endl;
         return -1;
     }
     return 0;


### PR DESCRIPTION
This PR changes the argument handling for the dir_path in main.cpp as follows:

If the wrong amount of arguments is provided, help on the usage of the application will be printed.
<img width="655" alt="image" src="https://user-images.githubusercontent.com/9566732/165842334-39cfe206-8316-4557-bb21-1c8c1165f439.png">

Custom `formatPath()` is replaced with `std::filesystem::canonical(argv[1]);`

```shell
# Handle paths as expected
./file_editor.out .
./file_editor.out relativePath/someDir
./file_editor.out /etc/someDir
./file_editor.out ../../someDir
``` 

The `canonical()` function also checks if the dir path exist and throws an error if not.
```shell
❯ ./file-editor.out doesNotExist/   
Unable to resolve the given directory path.
filesystem error: in canonical: No such file or directory ["doesNotExist/"] ["/Users/andi/dev/file-editor_OWN_CPP/build/bin"]
```
