### PR TITLE
Refactor init.cpp for better readability

### DIFF
--- a/include/file_editor.hpp
+++ b/include/file_editor.hpp
@@ -142,6 +142,10 @@ class FileEditor {
     int editorRowCxToRx();
     void editorScroll();
 
+    /* ANSI Escape Sequence for terminals */
+    inline static const char* TERM_CLEAR_SCREEN = "\x1b[2J";
+    inline static const char* TERM_SEND_CURSOR_HOME = "\x1b[H";
+
  public:
     // Init
     explicit FileEditor(std::string argv);

--- a/src/file_editor/init.cpp
+++ b/src/file_editor/init.cpp
@@ -3,21 +3,17 @@
 
 /*Removes the program from the screen and exits.*/
 void FileEditor::die(const char *s) {
-    write(STDOUT_FILENO, "\x1b[2J", 4);
-    write(STDOUT_FILENO, "\x1b[H", 3);
+    write(STDOUT_FILENO, TERM_CLEAR_SCREEN, 4);
+    write(STDOUT_FILENO, TERM_SEND_CURSOR_HOME, 3);
 
     perror(s);
 }
 
 /* Init */
-FileEditor::FileEditor(std::string argv) {
+FileEditor::FileEditor(std::string dir_path) {
     E.statusmsg[0] = '\0';
-    complete_path = argv;
-    if (pathExist()) {
-        this->createFileList();
-    } else {
-        throw std::invalid_argument("Path could not be found");
-    }
+    complete_path = dir_path;
+    this->createFileList();
 }
 
 // Destructor functions


### PR DESCRIPTION
This PR 

- Add two consts for cryptic terminal commands to allow better understanding of what happens when called the `write` func.
```c++
write(STDOUT_FILENO, TERM_CLEAR_SCREEN, 4);
write(STDOUT_FILENO, TERM_SEND_CURSOR_HOME, 3);
```

- Remove `if (pathExist())` check since the existence of the path is already checked in the `main.cpp` by the `std::filesystem::canonical(some_path)` func.