### PR TITLE
Add enum for file extension types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,6 @@ add_executable(file-editor.out
     src/file_editor/editor_handling.cpp
     src/file_editor/file_handling.cpp
     src/file_editor/terminal_handling.cpp
+    src/file_type/file_type.cpp
+    include/file_type.hpp
     include/file_editor.hpp)

--- a/include/file_type.hpp
+++ b/include/file_type.hpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <string>
+#include <algorithm>
 
 namespace filetype {
     enum class FileType { md, cpp, txt };

--- a/include/file_type.hpp
+++ b/include/file_type.hpp
@@ -1,0 +1,15 @@
+// Copyright 2022 Andreas Bauer
+
+#ifndef INCLUDE_FILE_TYPE_HPP_
+#define INCLUDE_FILE_TYPE_HPP_
+
+#include <iostream>
+
+namespace filetype {
+    enum class FileType { md, cpp, txt };
+
+    FileType fileTypeFromStr(const std::string val);
+    std::string fileTypeToStr(FileType type);
+}
+
+#endif

--- a/include/file_type.hpp
+++ b/include/file_type.hpp
@@ -4,6 +4,7 @@
 #define INCLUDE_FILE_TYPE_HPP_
 
 #include <iostream>
+#include <string>
 
 namespace filetype {
     enum class FileType { md, cpp, txt };
@@ -12,4 +13,4 @@ namespace filetype {
     std::string fileTypeToStr(FileType type);
 }
 
-#endif
+#endif  // INCLUDE_FILE_TYPE_HPP_

--- a/src/file_type/file_type.cpp
+++ b/src/file_type/file_type.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Andreas Bauer
+
 #include "include/file_type.hpp"
 
 namespace filetype {
@@ -12,7 +14,7 @@ std::string fileTypeToStr(FileType type) {
 }
 
 FileType fileTypeFromStr(const std::string file_ext) {
-    std::string lower_ext (file_ext);
+    std::string lower_ext(file_ext);
     std::for_each(lower_ext.begin(), lower_ext.end(), [](char & c){
       c = ::tolower(c);
     });
@@ -39,5 +41,4 @@ FileType fileTypeFromStr(const std::string file_ext) {
     return FileType::txt;
 }
 
-}
-
+}  // namespace filetype

--- a/src/file_type/file_type.cpp
+++ b/src/file_type/file_type.cpp
@@ -1,0 +1,43 @@
+#include "include/file_type.hpp"
+
+namespace filetype {
+
+std::string fileTypeToStr(FileType type) {
+    switch (type) {
+        case FileType::cpp: return "C/C++";
+        case FileType::md: return "Markdown";
+        case FileType::txt:
+        default: return "Textfile";
+    }
+}
+
+FileType fileTypeFromStr(const std::string file_ext) {
+    std::string lower_ext (file_ext);
+    std::for_each(lower_ext.begin(), lower_ext.end(), [](char & c){
+      c = ::tolower(c);
+    });
+
+    auto isCPP = "cpp" == lower_ext
+      || "hpp" == lower_ext
+      || "c" == lower_ext
+      || "cc" == lower_ext
+      || "h" == lower_ext;
+    if (isCPP) {
+        return FileType::cpp;
+    }
+
+    auto isMarkdown = "md" == lower_ext
+      || "markdown" == lower_ext
+      || "mdown" == lower_ext
+      || "mkdn" == lower_ext
+      || "mkd" == lower_ext
+      || "Rmd" == lower_ext;
+    if (isMarkdown) {
+        return FileType::md;
+    }
+
+    return FileType::txt;
+}
+
+}
+


### PR DESCRIPTION
This PR introduces an enum for file extension types that can be used across the whole application.

The two helper functions ensure an safe usage.

```cpp
using namespace filetype;

FileType ft = fileTypeFromStr("md");

std::string text = fileTypeToStr(FileType::cpp);
```