### PR TITLE
Add FileType to paths struct

### DIFF
--- a/include/file_editor.hpp
+++ b/include/file_editor.hpp
@@ -23,6 +23,7 @@
 #endif
 
 #include "include/syntax_highlight.hpp"
+#include "include/file_type.hpp"
 
 #define _BSD_SOURCE
 
@@ -30,6 +31,7 @@
 #define TAB_STOP 4
 #define QUIT_TIMES 2
 namespace fs = std::filesystem;
+using namespace filetype;
 
 class FileEditor {
  private:
@@ -55,6 +57,7 @@ class FileEditor {
     struct paths {
         char* filename;
         char* path;
+        FileType filetype;
         int size;
     };
     struct file_path_list {

--- a/include/file_type.hpp
+++ b/include/file_type.hpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 
 namespace filetype {
-    enum class FileType { md, cpp, txt };
+    enum class FileType { txt, md, cpp };
 
     FileType fileTypeFromStr(const std::string val);
     std::string fileTypeToStr(FileType type);

--- a/src/file_editor/file_handling.cpp
+++ b/src/file_editor/file_handling.cpp
@@ -34,6 +34,10 @@ void FileEditor::createFileList() {
         memcpy(file_list.p[file_list.size].path, placeholder.c_str(), len);
         file_list.p[file_list.size].path[len] = '\0';
         file_list.p[file_list.size].size = len;
+
+        auto file_extension = filename.substr(filename.find_last_of(".") + 1);
+        file_list.p[file_list.size].filetype = fileTypeFromStr(file_extension);
+
         file_list.size++;
     }
 }


### PR DESCRIPTION
Add `FileType` to `paths` struct so it can be used by syntax highlighter or other modules.
This way the file type will be determined only once when `paths` struct will be initiated. 